### PR TITLE
Restructure project to follow standard Go layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+containix

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Containix
+
+A terminal UI for managing Docker containers.
+
+## Project Structure
+
+The project follows a standard Go project layout:
+
+```
+containix/
+├── cmd/                  # Command-line applications
+│   └── containix/        # Main application entry point
+├── internal/             # Private application code
+│   ├── app/              # Application initialization
+│   ├── docker/           # Docker client and operations
+│   └── ui/               # User interface
+│       ├── components/   # Reusable UI components
+│       └── views/        # Application views/screens
+├── pkg/                  # Public libraries (for potential reuse)
+└── main.go               # Backward compatibility wrapper
+```
+
+## Development
+
+### Building
+
+```bash
+go build -o containix ./cmd/containix
+```
+
+### Running
+
+```bash
+./containix
+```
+
+## Features
+
+- List all Docker containers
+- Start, stop, and restart containers
+- View container logs
+- Real-time updates
+
+## Keyboard Shortcuts
+
+- `s`: Stop the selected container
+- `t`: Start the selected container
+- `x`: Restart the selected container
+- `l`: View logs of the selected container
+- `r`: Refresh the container list
+- `q`: Quit the application

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Ensure Go is installed
+if ! command -v go &> /dev/null; then
+    echo "Go is not installed. Please install Go to build this project."
+    exit 1
+fi
+
+# Update dependencies
+go mod tidy
+
+# Build the application
+go build -o containix ./cmd/containix
+
+echo "Build completed successfully. Run ./containix to start the application."

--- a/cmd/containix/main.go
+++ b/cmd/containix/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/shubhamku044/containix/internal/app"
+
+func main() {
+	app.Run()
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,15 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/shubhamku044/containix/internal/ui"
+)
+
+// Run initializes and starts the application
+func Run() {
+	p := tea.NewProgram(ui.NewMainModel())
+
+	if err := p.Start(); err != nil {
+		panic(err)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,3 +13,4 @@ func Run() {
 		panic(err)
 	}
 }
+

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -1,0 +1,91 @@
+package docker
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+)
+
+// Client wraps the Docker client and provides container operations
+type Client struct {
+	client *client.Client
+}
+
+// NewClient creates a new Docker client
+func NewClient() (*Client, error) {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.48"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		client: cli,
+	}, nil
+}
+
+// Container represents a Docker container
+type Container struct {
+	ID     string
+	Name   string
+	Status string
+}
+
+// ListContainers returns a list of all containers
+func (c *Client) ListContainers() ([]Container, error) {
+	containers, err := c.client.ContainerList(context.Background(), container.ListOptions{All: true})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]Container, len(containers))
+	for i, container := range containers {
+		name := "Unnamed"
+		if len(container.Names) > 0 {
+			name = strings.TrimPrefix(container.Names[0], "/")
+		}
+		result[i] = Container{
+			ID:     container.ID,
+			Name:   name,
+			Status: container.State,
+		}
+	}
+
+	return result, nil
+}
+
+// StopContainer stops a container
+func (c *Client) StopContainer(containerID string) error {
+	return c.client.ContainerStop(context.Background(), containerID, container.StopOptions{})
+}
+
+// StartContainer starts a container
+func (c *Client) StartContainer(containerID string) error {
+	return c.client.ContainerStart(context.Background(), containerID, container.StartOptions{})
+}
+
+// RestartContainer restarts a container
+func (c *Client) RestartContainer(containerID string) error {
+	return c.client.ContainerRestart(context.Background(), containerID, container.StopOptions{})
+}
+
+// GetContainerLogs returns the logs of a container
+func (c *Client) GetContainerLogs(containerID string) (string, error) {
+	reader, err := c.client.ContainerLogs(context.Background(), containerID, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	logs, err := io.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+
+	return string(logs), nil
+}

--- a/internal/ui/components/modal.go
+++ b/internal/ui/components/modal.go
@@ -1,0 +1,72 @@
+package components
+
+import (
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ModalModel represents a modal dialog
+type ModalModel struct {
+	viewport    viewport.Model
+	content     string
+	width       int
+	height      int
+	parentModel tea.Model
+}
+
+// NewModal creates a new modal
+func NewModal(content string, width, height int, parentModel tea.Model) ModalModel {
+	vp := viewport.New(width-4, height-6)
+	vp.SetContent(content)
+	
+	return ModalModel{
+		viewport:    vp,
+		content:     content,
+		width:       width,
+		height:      height,
+		parentModel: parentModel,
+	}
+}
+
+// Update updates the model
+func (m ModalModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc":
+			return m.parentModel, nil
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.viewport.Width = msg.Width - 4
+		m.viewport.Height = msg.Height - 6
+	}
+
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+// View renders the model
+func (m ModalModel) View() string {
+	modalWidth := m.width * 80 / 100
+	modalHeight := m.height * 70 / 100
+
+	modalStyle := lipgloss.NewStyle().
+		Width(modalWidth).
+		Height(modalHeight).
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		Padding(1, 2)
+
+	content := modalStyle.Render(m.viewport.View())
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		content,
+	)
+}

--- a/internal/ui/components/modal.go
+++ b/internal/ui/components/modal.go
@@ -19,7 +19,7 @@ type ModalModel struct {
 func NewModal(content string, width, height int, parentModel tea.Model) ModalModel {
 	vp := viewport.New(width-4, height-6)
 	vp.SetContent(content)
-	
+
 	return ModalModel{
 		viewport:    vp,
 		content:     content,
@@ -70,3 +70,4 @@ func (m ModalModel) View() string {
 		content,
 	)
 }
+

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/shubhamku044/containix/internal/ui/views"
+)
+
+// MainModel is the main model for the application
+type MainModel struct {
+	containerList views.ContainerListModel
+	logView       views.LogViewModel
+	focusLeft     bool
+}
+
+// NewMainModel creates a new main model
+func NewMainModel() tea.Model {
+	containerList, err := views.NewContainerListModel()
+	if err != nil {
+		panic(err)
+	}
+	
+	return MainModel{
+		containerList: containerList,
+		logView:       views.NewLogViewModel(),
+		focusLeft:     true,
+	}
+}
+
+// Init initializes the model
+func (m MainModel) Init() tea.Cmd {
+	return m.containerList.Init()
+}
+
+// Update updates the model
+func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "tab":
+			m.focusLeft = !m.focusLeft
+			return m, nil
+		case "q":
+			return m, tea.Quit
+		}
+	}
+
+	if m.focusLeft {
+		var newModel tea.Model
+		newModel, cmd = m.containerList.Update(msg)
+		m.containerList = newModel.(views.ContainerListModel)
+	}
+
+	return m, cmd
+}
+
+// View renders the model
+func (m MainModel) View() string {
+	left := m.containerList.View()
+	right := m.logView.View()
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+}

--- a/internal/ui/views/container_list.go
+++ b/internal/ui/views/container_list.go
@@ -1,0 +1,239 @@
+package views
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/viewport"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/shubhamku044/containix/internal/docker"
+)
+
+// ContainerListModel represents the container list view
+type ContainerListModel struct {
+	list         list.Model
+	dockerClient *docker.Client
+	err          error
+	logs         string
+	showingLogs  bool
+	width        int
+	height       int
+	logsViewport viewport.Model
+}
+
+// ContainerItem represents a container in the list
+type ContainerItem struct {
+	id     string
+	title  string
+	status string
+}
+
+func (i ContainerItem) Title() string       { return i.title }
+func (i ContainerItem) Description() string { return i.status }
+func (i ContainerItem) FilterValue() string { return i.title }
+
+// ContainersFetchedMsg is sent when containers are fetched
+type ContainersFetchedMsg struct {
+	Items []list.Item
+}
+
+// ErrMsg is sent when an error occurs
+type ErrMsg struct {
+	Err error
+}
+
+// LogsMsg is sent when logs are fetched
+type LogsMsg struct {
+	Logs string
+}
+
+// NewContainerListModel creates a new container list model
+func NewContainerListModel() (ContainerListModel, error) {
+	cli, err := docker.NewClient()
+	if err != nil {
+		return ContainerListModel{}, err
+	}
+
+	l := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
+	l.Title = "Containers"
+	l.Styles.Title = lipgloss.NewStyle().MarginLeft(2)
+
+	vp := viewport.New(0, 0)
+
+	return ContainerListModel{
+		list:         l,
+		dockerClient: cli,
+		logsViewport: vp,
+	}, nil
+}
+
+// Init initializes the model
+func (m ContainerListModel) Init() tea.Cmd {
+	return tea.Batch(
+		m.fetchContainers(),
+		tea.EnterAltScreen,
+	)
+}
+
+// fetchContainers fetches containers from Docker
+func (m *ContainerListModel) fetchContainers() tea.Cmd {
+	return func() tea.Msg {
+		containers, err := m.dockerClient.ListContainers()
+		if err != nil {
+			return ErrMsg{Err: err}
+		}
+
+		items := make([]list.Item, len(containers))
+		for i, c := range containers {
+			items[i] = ContainerItem{
+				id:     c.ID,
+				title:  c.Name,
+				status: c.Status,
+			}
+		}
+		return ContainersFetchedMsg{Items: items}
+	}
+}
+
+// stopContainer stops a container
+func (m *ContainerListModel) stopContainer(containerID string) tea.Cmd {
+	return func() tea.Msg {
+		err := m.dockerClient.StopContainer(containerID)
+		if err != nil {
+			return ErrMsg{Err: err}
+		}
+		return nil
+	}
+}
+
+// startContainer starts a container
+func (m *ContainerListModel) startContainer(containerID string) tea.Cmd {
+	return func() tea.Msg {
+		err := m.dockerClient.StartContainer(containerID)
+		if err != nil {
+			return ErrMsg{Err: err}
+		}
+		return nil
+	}
+}
+
+// restartContainer restarts a container
+func (m *ContainerListModel) restartContainer(containerID string) tea.Cmd {
+	return func() tea.Msg {
+		err := m.dockerClient.RestartContainer(containerID)
+		if err != nil {
+			return ErrMsg{Err: err}
+		}
+		return nil
+	}
+}
+
+// fetchLogs fetches logs for a container
+func (m *ContainerListModel) fetchLogs(containerID string) tea.Cmd {
+	return func() tea.Msg {
+		logs, err := m.dockerClient.GetContainerLogs(containerID)
+		if err != nil {
+			return ErrMsg{Err: err}
+		}
+		return LogsMsg{Logs: logs}
+	}
+}
+
+// Update updates the model
+func (m ContainerListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.list.SetSize(msg.Width-4, msg.Height-6)
+
+	case ContainersFetchedMsg:
+		m.list.SetItems(msg.Items)
+		return m, nil
+
+	case ErrMsg:
+		m.err = msg.Err
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "r":
+			return m, m.fetchContainers()
+		case "s":
+			if selectedItem, ok := m.list.SelectedItem().(ContainerItem); ok {
+				return m, tea.Sequence(
+					m.stopContainer(selectedItem.id),
+					m.fetchContainers(),
+				)
+			}
+		case "t":
+			if selectedItem, ok := m.list.SelectedItem().(ContainerItem); ok {
+				return m, tea.Sequence(
+					m.startContainer(selectedItem.id),
+					m.fetchContainers(),
+				)
+			}
+		case "x":
+			if selectedItem, ok := m.list.SelectedItem().(ContainerItem); ok {
+				return m, tea.Sequence(
+					m.restartContainer(selectedItem.id),
+					m.fetchContainers(),
+				)
+			}
+		case "l":
+			if selectedItem, ok := m.list.SelectedItem().(ContainerItem); ok {
+				m.showingLogs = true
+				return m, m.fetchLogs(selectedItem.id)
+			}
+		case "q":
+			if m.showingLogs {
+				m.showingLogs = false
+				m.logs = ""
+			} else {
+				return m, tea.Quit
+			}
+		}
+
+	case LogsMsg:
+		m.logs = msg.Logs
+		m.logsViewport.SetContent(msg.Logs)
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+// View renders the model
+func (m ContainerListModel) View() string {
+	if m.err != nil {
+		return lipgloss.NewStyle().
+			Width(m.width).
+			Height(m.height).
+			Padding(1, 2).
+			Render("Error: " + m.err.Error() + "\nPress R to retry")
+	}
+
+	if m.showingLogs {
+		return lipgloss.NewStyle().
+			Width(m.width).
+			Height(m.height).
+			Padding(1, 2).
+			Render(m.logsViewport.View() + "\n\nPress 'q' to return")
+	}
+
+	listView := lipgloss.NewStyle().
+		Width(m.width - 4).
+		Height(m.height - 6).
+		Render(m.list.View())
+
+	helpText := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		Render("\n  s: stop • t: start • x: restart • l: logs • r: refresh • q: quit")
+
+	return lipgloss.NewStyle().
+		Width(m.width).
+		Height(m.height).
+		Padding(1, 2).
+		Render(listView + helpText)
+}

--- a/internal/ui/views/log_view.go
+++ b/internal/ui/views/log_view.go
@@ -1,0 +1,31 @@
+package views
+
+import (
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// LogViewModel represents the log view
+type LogViewModel struct {
+	viewport viewport.Model
+}
+
+// NewLogViewModel creates a new log view model
+func NewLogViewModel() LogViewModel {
+	vp := viewport.New(50, 20)
+	vp.SetContent("← Select a container to view logs here.")
+	return LogViewModel{viewport: vp}
+}
+
+// Update updates the model
+func (m LogViewModel) Update(msg tea.Msg) (LogViewModel, tea.Cmd) {
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+// View renders the model
+func (m LogViewModel) View() string {
+	return lipgloss.NewStyle().Padding(1).Width(50).Render(m.viewport.View())
+}

--- a/main.go
+++ b/main.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-        "os"
-        "os/exec"
-        "path/filepath"
+	"os"
+	"os/exec"
+	"path/filepath"
 )
 
 func main() {
-        // This is a wrapper that calls the actual application in cmd/containix
-        // This allows for backward compatibility while using the new structure
-        cmd := exec.Command(filepath.Join("cmd", "containix", "containix"))
-        cmd.Stdin = os.Stdin
-        cmd.Stdout = os.Stdout
-        cmd.Stderr = os.Stderr
-        if err := cmd.Run(); err != nil {
-                panic(err)
-        }
+	// This is a wrapper that calls the actual application in cmd/containix
+	// This allows for backward compatibility while using the new structure
+	cmd := exec.Command(filepath.Join("cmd", "containix", "containix"))
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		panic(err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,19 @@
 package main
 
-import "github.com/shubhamku044/containix/cmd"
+import (
+        "os"
+        "os/exec"
+        "path/filepath"
+)
 
 func main() {
-	cmd.Execute()
+        // This is a wrapper that calls the actual application in cmd/containix
+        // This allows for backward compatibility while using the new structure
+        cmd := exec.Command(filepath.Join("cmd", "containix", "containix"))
+        cmd.Stdin = os.Stdin
+        cmd.Stdout = os.Stdout
+        cmd.Stderr = os.Stderr
+        if err := cmd.Run(); err != nil {
+                panic(err)
+        }
 }


### PR DESCRIPTION
## Description

This PR restructures the project to follow the standard Go project layout, making it more maintainable as it grows.

### Changes

- Created a standard Go project structure with `cmd`, `internal`, and `pkg` directories
- Separated concerns by moving Docker-related functionality to its own package
- Split UI components into separate files and packages
- Added a comprehensive README with project structure documentation
- Created a build script for easier building
- Maintained backward compatibility with the original entry point

### Benefits

- Better organization of code
- Clearer separation of concerns
- Improved maintainability
- Easier to understand for new contributors
- Follows Go best practices

### Testing

The restructured code maintains the same functionality as before but with a cleaner organization.